### PR TITLE
Improve compatibility with non-Sunmi devices

### DIFF
--- a/android/src/main/java/com/reactnativesunmiprinter/SunmiPrinterModule.java
+++ b/android/src/main/java/com/reactnativesunmiprinter/SunmiPrinterModule.java
@@ -215,6 +215,7 @@ public class SunmiPrinterModule extends ReactContextBaseJavaModule {
   /**
    * 是否存在打印机服务
    */
+  @ReactMethod
   public boolean hasPrinter() {
     final boolean hasPrinterService = printerService != null;
     return hasPrinterService;

--- a/android/src/main/java/com/reactnativesunmiprinter/SunmiPrinterModule.java
+++ b/android/src/main/java/com/reactnativesunmiprinter/SunmiPrinterModule.java
@@ -215,9 +215,9 @@ public class SunmiPrinterModule extends ReactContextBaseJavaModule {
    * 是否存在打印机服务
    */
   @ReactMethod
-  public boolean hasPrinter() {
+  public void hasPrinter(Promise promise) {
     final boolean hasPrinterService = printerService != null;
-    return hasPrinterService;
+    promise.resolve(hasPrinterService);
   }
 
   /**

--- a/android/src/main/java/com/reactnativesunmiprinter/SunmiPrinterModule.java
+++ b/android/src/main/java/com/reactnativesunmiprinter/SunmiPrinterModule.java
@@ -6,7 +6,6 @@ import android.graphics.Bitmap;
 import android.os.RemoteException;
 import android.util.Base64;
 import android.util.Log;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
@@ -83,7 +82,7 @@ public class SunmiPrinterModule extends ReactContextBaseJavaModule {
     try {
       InnerPrinterManager.getInstance().bindService(reactContext, innerPrinterCallback);
     } catch (RemoteException e) {
-      Toast.makeText(getReactApplicationContext(), "failed", Toast.LENGTH_LONG).show();
+      Log.i(TAG, "ERROR: " + e.getMessage());
     }
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -320,6 +320,10 @@ type SunmiPrinterType = {
    * @param type
    */
   printBitmapCustom: (bitmap: any, type: number) => void;
+  /**
+   * 是否存在打印机服务
+   */
+  hasPrinter: () => boolean;
 };
 
 type SunmiScanType = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -323,7 +323,7 @@ type SunmiPrinterType = {
   /**
    * 是否存在打印机服务
    */
-  hasPrinter: () => boolean;
+  hasPrinter: () => Promise<boolean>;
 };
 
 type SunmiScanType = {


### PR DESCRIPTION
Hi, 

I would like to use this library also in non-Sunmi devices. Currently there's no easy way to check if the device is a Sunmi, without triggering an uncatchable error.

I found the `hasPrinter` method which seems perfect for this. 