### PR TITLE
fix: Upgraded minSdkVersion from 19 to 21

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,5 +55,5 @@ repositories {
 dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
-  implementation "com.sunmi:printerlibrary:1.0.18"
+  implementation "com.sunmi:printerlibrary:1.0.13"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ android {
   compileSdkVersion safeExtGet('SunmiPrinter_compileSdkVersion', 29)
   buildToolsVersion safeExtGet('SunmiPrinter_buildToolsVersion', '29.0.2')
   defaultConfig {
-    minSdkVersion safeExtGet('SunmiPrinter_minSdkVersion', 19)
+    minSdkVersion safeExtGet('SunmiPrinter_minSdkVersion', 21)
     targetSdkVersion safeExtGet('SunmiPrinter_targetSdkVersion', 29)
     versionCode 1
     versionName "1.0"
@@ -55,5 +55,5 @@ repositories {
 dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
-  implementation "com.sunmi:printerlibrary:1.0.13"
+  implementation "com.sunmi:printerlibrary:1.0.18"
 }


### PR DESCRIPTION
fix: Upgraded minSdkVersion from 19 to 21 to be compatible with react-native@0.71.7 latest version

issue fixes: https://github.com/Surile/react-native-sunmi-printer/issues/27 https://github.com/Surile/react-native-sunmi-printer/issues/26 @Surile 
