### PR TITLE
Add printBitmapBase64Custom such as printBitmapCustom supports Base64

### DIFF
--- a/android/src/main/java/com/reactnativesunmiprinter/SunmiPrinterModule.java
+++ b/android/src/main/java/com/reactnativesunmiprinter/SunmiPrinterModule.java
@@ -412,6 +412,25 @@ public class SunmiPrinterModule extends ReactContextBaseJavaModule {
   }
 
   /**
+   * 打印图⽚(3)
+   * 图⽚像素分辨率⼩于200万，且宽度根据纸张规格设置（58为384像素，80为576像素），如果超
+   * 过纸张宽度将不显示
+   *
+   * @param bitmap
+   * @param type
+   */
+  @ReactMethod
+  public void printBitmapBase64Custom(String encodedString, int pixelWidth, int type) throws RemoteException {
+    final String pureBase64Encoded = encodedString.substring(encodedString.indexOf(",") + 1);
+    final byte[] decodedBytes = Base64.decode(pureBase64Encoded, Base64.DEFAULT);
+    Bitmap decodedBitmap = BitmapFactory.decodeByteArray(decodedBytes, 0, decodedBytes.length);
+	  int w = decodedBitmap.getWidth();
+    Integer h = decodedBitmap.getHeight();
+    Bitmap scaledImage = Bitmap.createScaledBitmap(decodedBitmap, pixelWidth, (pixelWidth / w) * h, false);
+    printerService.printBitmapCustom(scaledImage, type, innerResultCallback);
+  }
+
+  /**
    * 打印⼀维条码
    *
    * @param data

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -336,7 +336,7 @@ type SunmiPrinterType = {
    * @param pixelWidth
    * @param type
    */
-    printBitmapBase64Custom: (encodedString: string, pixelWidth:number, type: number) => void;
+  printBitmapBase64Custom: (encodedString: string, pixelWidth:number, type: number) => void;
   /**
    * 是否存在打印机服务
    */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -327,6 +327,16 @@ type SunmiPrinterType = {
    * @param type
    */
   printBitmapCustom: (bitmap: any, type: number) => void;
+    /**
+   * 打印图⽚(3)
+   * 图⽚像素分辨率⼩于200万，且宽度根据纸张规格设置（58为384像素，80为576像素），如果超
+   * 过纸张宽度将不显示
+   *
+   * @param encodedString
+   * @param pixelWidth
+   * @param type
+   */
+    printBitmapBase64Custom: (encodedString: string, pixelWidth:number, type: number) => void;
   /**
    * 是否存在打印机服务
    */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -327,7 +327,7 @@ type SunmiPrinterType = {
    * @param type
    */
   printBitmapCustom: (bitmap: any, type: number) => void;
-    /**
+  /**
    * 打印图⽚(3)
    * 图⽚像素分辨率⼩于200万，且宽度根据纸张规格设置（58为384像素，80为576像素），如果超
    * 过纸张宽度将不显示


### PR DESCRIPTION
Hello.

Your library is very useful.

I want printBitmapCustom which can support Base64 image as well as printBitmap, so I made a PR.
I don't understand Chinese, so I change only a number in the comments.

This printBitmapBase64Custom has been tested in my application.
https://www.youtube.com/watch?v=yuoYod6Y_Ao




