### PR TITLE
Fix security exception on Android 14.

### DIFF
--- a/android/src/main/java/com/reactnativesunmiprinter/SunmiScanModule.java
+++ b/android/src/main/java/com/reactnativesunmiprinter/SunmiScanModule.java
@@ -95,7 +95,7 @@ public class SunmiScanModule extends ReactContextBaseJavaModule {
   private void registerReceiver() {
     IntentFilter filter = new IntentFilter();
     filter.addAction(ACTION_DATA_CODE_RECEIVED);
-    reactContext.registerReceiver(receiver, filter);
+    reactContext.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED);
   }
 
   private static void sendEvent(String msg) {


### PR DESCRIPTION
When running on Android 14, the app crashes immediately with the following error: 

> One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts

<img width="342" alt="Capture d’écran 2024-03-18 à 18 03 31" src="https://github.com/Surile/react-native-sunmi-printer/assets/1162230/0c625644-0198-42f1-a5e2-6c184b456b5f">

--- 

This is a hotfix, seems a better solution would be to use `ContextCompat`
